### PR TITLE
fix overlap plots

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ GeometryBasics = "0.3"
 LightGraphs = "1"
 NetworkLayout = "0.3, 0.4"
 Plots = "1"
+Plasmo = "0.4"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+GR = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 NetworkLayout = "46757867-2c16-5918-afeb-47bfcb05e46a"
@@ -17,7 +18,6 @@ Colors = "0.12"
 GeometryBasics = "0.3"
 LightGraphs = "1"
 NetworkLayout = "0.3, 0.4"
-Plasmo = "0.4"
 Plots = "1"
 julia = "1"
 

--- a/src/layout_plot.jl
+++ b/src/layout_plot.jl
@@ -163,7 +163,7 @@ function layout_plot(graph::OptiGraph,subgraphs::Vector{OptiGraph};
     # hypergraph,hyper_map = gethypergraph(graph)
     # clique_graph,clique_map = clique_expansion(hypergraph)
     clique_graph,clique_map = Plasmo.clique_graph(graph)
-    lgraph = clique_graph#.lightgraph
+    lgraph = clique_graph.graph
 
 
     startpositions = Array{Point{2,Float32},1}()


### PR DESCRIPTION
access the underlying lightgraph directly on overlap plots.
this also add the GR package as a dependency.